### PR TITLE
Improve the collision system

### DIFF
--- a/Perceptions/Core.gd
+++ b/Perceptions/Core.gd
@@ -15,6 +15,8 @@ func _ready() -> void:
 
 func _physics_process(delta: float) -> void:
 	
+	_nucleus_collision()
+	
 	if self.is_on_floor(): 
 		_ground_movement();
 	else: 
@@ -29,3 +31,6 @@ func _air_movement(d : float) -> void:
 func _ground_movement() -> void:
 	if Input.is_action_pressed("main"):
 		velocity.y = JUMP_VELOCITY;
+		
+func _nucleus_collision() -> void:
+	$Nucleus.modulate = Color.RED if $Nucleus.has_overlapping_bodies() else Color.GREEN_YELLOW;

--- a/Perceptions/Core.tscn
+++ b/Perceptions/Core.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://dfvncwmweby48"]
+[gd_scene load_steps=4 format=3 uid="uid://dfvncwmweby48"]
 
 [ext_resource type="Script" path="res://Perceptions/Core.gd" id="1_opurh"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_rd2ky"]
 size = Vector2(128, 128)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_hdcld"]
+size = Vector2(96, 96)
 
 [node name="Core" type="CharacterBody2D"]
 script = ExtResource("1_opurh")
@@ -16,6 +19,14 @@ offset_bottom = 64.0
 size_flags_horizontal = 4
 color = Color(0.752941, 0.388235, 0.388235, 1)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="Collision" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_rd2ky")
 debug_color = Color(0, 0.6, 0.701961, 0.419608)
+
+[node name="Nucleus" type="Area2D" parent="."]
+collision_layer = 2
+collision_mask = 2
+
+[node name="Collision" type="CollisionShape2D" parent="Nucleus"]
+shape = SubResource("RectangleShape2D_hdcld")
+debug_color = Color(1, 1, 1, 0.698039)

--- a/Stages/TestStage.tscn
+++ b/Stages/TestStage.tscn
@@ -11,9 +11,12 @@ position = Vector2(968, 592)
 polygon = PackedVector2Array(64, 0, 64, -256, 128, -256, 128, 56, 192, 56, 192, 8, 256, 8, 320, 8, 320, 216, 464, 216, 464, -8, 480, -8, 480, 248, -488, 248, -488, 24, -64, 24, -64, 0)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="Polygon2D"]
+collision_layer = 3
+collision_mask = 3
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Polygon2D/StaticBody2D"]
 polygon = PackedVector2Array(-488, 24, -488, 248, 480, 248, 480, -8, 464, -8, 464, 216, 320, 216, 320, 8, 192, 8, 192, 56, 128, 56, 128, -256, 64, -256, 64, 0, -8, 0, -64, 0, -64, 24)
+one_way_collision = true
 
 [node name="Core" parent="." instance=ExtResource("1_mui20")]
 position = Vector2(416, 480)

--- a/Stages/TestStage.tscn
+++ b/Stages/TestStage.tscn
@@ -21,6 +21,3 @@ position = Vector2(416, 480)
 [node name="Camera" type="Camera2D" parent="."]
 position = Vector2(968, 592)
 zoom = Vector2(0.7, 0.7)
-limit_smoothed = true
-position_smoothing_enabled = true
-position_smoothing_speed = 10.0


### PR DESCRIPTION
With this PR the collision detection has been split into two elements:

- The main collider that is a direct child of the "core", its main purpose is to resolve interactions with the floor the "core" is on.
- The "nucleus" ( smaller and centered in the "core" ), which does not collide strictly speaking, its purpose is to act as a hurt box of sorts. Contact with it will count as a death.

This "dual collider" approach allows for a degree of leniency when interacting with elements of structural nature in a stage, mainly it makes jumping onto objects more forgiving, without it the slightest clipping would result in death, reducing enjoy-ability.

The colour shifting of the nucleus based on whether it is in contact serves for debugging better