### PR TITLE
Setup bindings and input handling for rhythm keys

### DIFF
--- a/Composer/Stage.cs
+++ b/Composer/Stage.cs
@@ -1,5 +1,4 @@
 using Godot;
-using XanaduProject.Perceptions;
 
 namespace XanaduProject.Composer;
 
@@ -7,7 +6,6 @@ namespace XanaduProject.Composer;
 public partial class Stage : WorldEnvironment
 {
     private Camera2D _camera = new();
-
     private Node2D _core;
 
 

--- a/Tests/InputTest.cs
+++ b/Tests/InputTest.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace XanaduProject.Tests;
+
+[GlobalClass]
+public partial class InputTest : CenterContainer
+{
+    public InputTest()
+    {
+        var container = new HBoxContainer();
+        AddChild(container);
+
+        foreach (var child in _addKeys)
+            container.AddChild(child);
+    }
+
+    private readonly List<InputRect> _addKeys = new()
+    {
+        new InputRect
+        {
+            Position = new Vector2(400,400),
+            Key = "main",
+            ColourOn = Colors.Yellow
+        },
+        new InputRect
+        {
+            Position = new Vector2(400,400),
+            Key = "R1",
+            ColourOn = Colors.Green
+        },
+        new InputRect
+        {
+            Position = new Vector2(400,400),
+            Key = "R2",
+            ColourOn = Colors.Orange
+        }
+    };
+
+    private ColorRect InputBox() =>
+        new() { Size = new Vector2(100, 100) };
+
+    private partial class InputRect : ColorRect
+    {
+        public Color ColourOn { get; set; }
+        public string Key { get; set; }
+
+        public InputRect() =>
+           CustomMinimumSize = new Vector2(100, 100);
+        
+        public override void _Process(double delta)
+        {
+            base._Process(delta);
+            Color = Input.IsActionPressed(Key) ? ColourOn : Colors.Black;
+        }
+    }
+}

--- a/Tests/InputTest.cs
+++ b/Tests/InputTest.cs
@@ -46,8 +46,20 @@ public partial class InputTest : CenterContainer
         public string Key { get; set; }
 
         public InputRect() =>
-           CustomMinimumSize = new Vector2(100, 100);
-        
+            CustomMinimumSize = new Vector2(100, 100);
+
+        public override void _Ready()
+        {
+            base._Ready();
+
+            AddChild(new Label
+            {
+                Text = Key,
+                LayoutMode = 1, 
+                AnchorsPreset = 8,
+            });
+        }
+
         public override void _Process(double delta)
         {
             base._Process(delta);

--- a/Tests/TestScene.tscn
+++ b/Tests/TestScene.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=2 format=3 uid="uid://do27umaklt2jb"]
+
+[ext_resource type="Script" path="res://Tests/InputTest.cs" id="1_7hp44"]
+
+[node name="TestScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="InputTest" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_7hp44")

--- a/project.godot
+++ b/project.godot
@@ -35,6 +35,16 @@ main={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+R1={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":74,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+R2={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":108,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
Adds two new "rhythm" keys, R1 and R2 these will serve for interacting with "paths" tied to rhythm in the future. 

A small test was added for viewing if keys are indeed functioning correctly:

![Screenshot_20230627_130905](https://github.com/mk56-spn/Xanadu/assets/74463310/1c9f2e52-7e90-4ceb-a75c-c8ba47ec6df8)

As can be seen here where the first key is unpressed.