### PR TITLE
Automate stage loading in "StageSelection"

### DIFF
--- a/Screens/StageSelection/StageSelection.cs
+++ b/Screens/StageSelection/StageSelection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) mk56_spn <dhsjplt@gmail.com>. Licensed under the GNU General Public Licence (2.0).
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using Godot;
 using XanaduProject.DataStructure;
 
@@ -8,14 +9,24 @@ namespace XanaduProject.Screens.StageSelection
 {
     public partial class StageSelection : Control
     {
+        private VBoxContainer trackList = null!;
+
         public override void _Ready()
         {
             base._Ready();
 
-            var trackList = GetNode<VBoxContainer>("TrackList");
+            trackList = GetNode<VBoxContainer>("TrackList");
 
-            trackList.AddChild(new StageSelectionPanel(ResourceLoader.Load<StageInfo>("res://Resources/Stages/Stage 1/Stage 1.tres")));
-            trackList.AddChild(new StageSelectionPanel(ResourceLoader.Load<StageInfo>("res://Resources/Stages/Stage 2/Stage 2.tres")));
+            // Code block filters through the files present in the "Stages" folder and retrieves the stage information for instantiation.
+            var dir = DirAccess.Open("res://Resources/Stages/");
+
+            foreach (string? folder in dir.GetDirectories())
+            {
+                string? file = DirAccess.Open($"{dir.GetCurrentDir()}{folder}").GetFiles().First(f => f.Contains(".tres"));
+                var resource = ResourceLoader.Load<StageInfo>($"{dir.GetCurrentDir()}{folder}/{file}");
+
+                trackList.AddChild(new StageSelectionPanel(resource));
+            }
         }
     }
 }


### PR DESCRIPTION
Paths to specific stages are no longer a thing. instead the "Stage" folder will be "scanned" for the relevant files.