### PR TITLE
Add stage selection tabbing

### DIFF
--- a/Screens/StageSelection/StageSelection.cs
+++ b/Screens/StageSelection/StageSelection.cs
@@ -9,13 +9,13 @@ namespace XanaduProject.Screens.StageSelection
 {
     public partial class StageSelection : Control
     {
-        private VBoxContainer trackList = null!;
+        private HBoxContainer trackList = null!;
 
         public override void _Ready()
         {
             base._Ready();
 
-            trackList = GetNode<VBoxContainer>("TrackList");
+            trackList = GetNode<HBoxContainer>("TrackList");
 
             // Code block filters through the files present in the "Stages" folder and retrieves the stage information for instantiation.
             var dir = DirAccess.Open("res://Resources/Stages/");

--- a/Screens/StageSelection/StageSelection.cs
+++ b/Screens/StageSelection/StageSelection.cs
@@ -16,6 +16,9 @@ namespace XanaduProject.Screens.StageSelection
         {
             base._Ready();
 
+            loadStages();
+        private void loadStages()
+        {
             // Code block filters through the files present in the "Stages" folder and retrieves the stage information for instantiation.
             var dir = DirAccess.Open("res://Resources/Stages/");
 
@@ -26,6 +29,8 @@ namespace XanaduProject.Screens.StageSelection
 
                 trackList.AddChild(new StageSelectionPanel(resource));
             }
+
+            GD.Print($"{trackList.GetChildCount()} stages were loaded");
         }
     }
 }

--- a/Screens/StageSelection/StageSelection.cs
+++ b/Screens/StageSelection/StageSelection.cs
@@ -9,13 +9,12 @@ namespace XanaduProject.Screens.StageSelection
 {
     public partial class StageSelection : Control
     {
+        [Export]
         private HBoxContainer trackList = null!;
 
         public override void _Ready()
         {
             base._Ready();
-
-            trackList = GetNode<HBoxContainer>("TrackList");
 
             // Code block filters through the files present in the "Stages" folder and retrieves the stage information for instantiation.
             var dir = DirAccess.Open("res://Resources/Stages/");

--- a/Screens/StageSelection/StageSelection.cs
+++ b/Screens/StageSelection/StageSelection.cs
@@ -11,12 +11,30 @@ namespace XanaduProject.Screens.StageSelection
     {
         [Export]
         private HBoxContainer trackList = null!;
+        [Export]
+        private Button startButton = null!;
+        [Export]
+        private Button backButton = null!;
+        [Export]
+        private Button nextButton = null!;
+
+        private StageInfo activeStage = null!;
 
         public override void _Ready()
         {
             base._Ready();
 
             loadStages();
+
+            foreach (var stagePanel in trackList.GetChildren().OfType<StageSelectionPanel>())
+                stagePanel.FocusEntered += () => activeStage = stagePanel.StageInfo;
+
+            // Sets the initial focused stage.
+            trackList.GetChildren().OfType<StageSelectionPanel>().FirstOrDefault()?.GrabFocus();
+
+            startButton.Pressed += () => GetTree().ChangeSceneToPacked(activeStage.Stage);
+        }
+
         private void loadStages()
         {
             // Code block filters through the files present in the "Stages" folder and retrieves the stage information for instantiation.

--- a/Screens/StageSelection/StageSelection.cs
+++ b/Screens/StageSelection/StageSelection.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Godot;
 using XanaduProject.DataStructure;
+using XanaduProject.Singletons;
 
 namespace XanaduProject.Screens.StageSelection
 {
@@ -32,8 +33,27 @@ namespace XanaduProject.Screens.StageSelection
             // Sets the initial focused stage.
             trackList.GetChildren().OfType<StageSelectionPanel>().FirstOrDefault()?.GrabFocus();
 
-            startButton.Pressed += () => GetTree().ChangeSceneToPacked(activeStage.Stage);
+            startButton.Pressed += () =>
+            {
+                GetNode<AudioSource>("/root/GlobalAudio").SetTrack(activeStage.TrackInfo);
+                GetTree().ChangeSceneToPacked(activeStage.Stage);
+            };
+
+            backButton.ButtonUp += () => focus(getFocusedStageIndex() -1);
+            nextButton.ButtonUp += () => focus(getFocusedStageIndex() +1);
+
+            void focus(int index)
+            {
+                if (index < trackList.GetChildCount() || index < 0)
+                    trackList.GetChild<StageSelectionPanel>(index).GrabFocus();
+            }
         }
+
+        private int getFocusedStageIndex() =>
+            trackList.GetChildren()
+                .OfType<StageSelectionPanel>()
+                .First(c => c.HasFocus()).GetIndex();
+
 
         private void loadStages()
         {

--- a/Screens/StageSelection/StageSelection.tscn
+++ b/Screens/StageSelection/StageSelection.tscn
@@ -14,7 +14,7 @@ fill_from = Vector2(0.5, 1)
 fill_to = Vector2(0.5, 0)
 metadata/_snap_enabled = true
 
-[node name="StageSelection" type="Control" node_paths=PackedStringArray("trackList")]
+[node name="StageSelection" type="Control" node_paths=PackedStringArray("trackList", "startButton", "backButton", "nextButton")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -23,6 +23,9 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_wapex")
 trackList = NodePath("TrackList")
+startButton = NodePath("StartButton")
+backButton = NodePath("BackButton")
+nextButton = NodePath("NextButton")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 1
@@ -57,6 +60,7 @@ anchor_right = 0.00416667
 anchor_bottom = 0.503704
 offset_left = 30.0
 grow_vertical = 2
+focus_mode = 0
 
 [node name="NextButton" type="Button" parent="."]
 custom_minimum_size = Vector2(70, 150)
@@ -69,3 +73,17 @@ anchor_bottom = 0.5
 offset_right = -30.0
 grow_horizontal = 0
 grow_vertical = 2
+focus_mode = 0
+
+[node name="StartButton" type="Button" parent="."]
+custom_minimum_size = Vector2(200, 60)
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_bottom = -30.0
+grow_horizontal = 2
+grow_vertical = 0
+focus_mode = 0

--- a/Screens/StageSelection/StageSelection.tscn
+++ b/Screens/StageSelection/StageSelection.tscn
@@ -33,7 +33,7 @@ grow_vertical = 2
 texture = SubResource("GradientTexture2D_byiok")
 metadata/_edit_lock_ = true
 
-[node name="TrackList" type="VBoxContainer" parent="."]
+[node name="TrackList" type="HBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5

--- a/Screens/StageSelection/StageSelection.tscn
+++ b/Screens/StageSelection/StageSelection.tscn
@@ -14,7 +14,7 @@ fill_from = Vector2(0.5, 1)
 fill_to = Vector2(0.5, 0)
 metadata/_snap_enabled = true
 
-[node name="StageSelection" type="Control"]
+[node name="StageSelection" type="Control" node_paths=PackedStringArray("trackList")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -22,6 +22,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_wapex")
+trackList = NodePath("TrackList")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 1

--- a/Screens/StageSelection/StageSelection.tscn
+++ b/Screens/StageSelection/StageSelection.tscn
@@ -47,3 +47,25 @@ offset_right = 60.0
 offset_bottom = 15.5
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="BackButton" type="Button" parent="."]
+custom_minimum_size = Vector2(70, 150)
+layout_mode = 1
+anchors_preset = -1
+anchor_top = 0.496296
+anchor_right = 0.00416667
+anchor_bottom = 0.503704
+offset_left = 30.0
+grow_vertical = 2
+
+[node name="NextButton" type="Button" parent="."]
+custom_minimum_size = Vector2(70, 150)
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_right = -30.0
+grow_horizontal = 0
+grow_vertical = 2

--- a/Screens/StageSelection/StageSelection.tscn
+++ b/Screens/StageSelection/StageSelection.tscn
@@ -87,3 +87,4 @@ offset_bottom = -30.0
 grow_horizontal = 2
 grow_vertical = 0
 focus_mode = 0
+text = "START"

--- a/Screens/StageSelection/StageSelectionPanel.cs
+++ b/Screens/StageSelection/StageSelectionPanel.cs
@@ -3,36 +3,40 @@
 
 using Godot;
 using XanaduProject.DataStructure;
-using XanaduProject.Singletons;
 
 namespace XanaduProject.Screens.StageSelection
 {
+    [GlobalClass]
     public partial class StageSelectionPanel : PanelContainer
     {
-        private readonly StageInfo stageInfo;
+        public StageInfo StageInfo { get; private set; }
+
+        private ColorRect focusRect = new ColorRect
+        {
+            SizeFlagsVertical = SizeFlags.ShrinkEnd,
+            Color = Colors.Transparent, CustomMinimumSize = new Vector2(0,10)
+        };
 
         public StageSelectionPanel(StageInfo stageInfo)
         {
-            this.stageInfo = stageInfo;
-        }
+            FocusMode = FocusModeEnum.All;
+            StageInfo = stageInfo;
+            CustomMinimumSize = new Vector2(200, 200);
 
-        public override void _Ready()
-        {
-            base._Ready();
-
-            var label = new Label { Text = stageInfo.Title };
-            var selectButton = new Button { Text = "PLAY" };
-            var container = new VBoxContainer { CustomMinimumSize = new Vector2(150, 0) };
-
-            AddChild(container);
-            container.AddChild(label);
-            container.AddChild(selectButton);
-
-            selectButton.Pressed += () =>
+            var label = new Label
             {
-                GetNode<AudioSource>("/root/GlobalAudio").SetTrack(stageInfo.TrackInfo);
-                GetTree().ChangeSceneToPacked(stageInfo.Stage);
+                CustomMinimumSize = CustomMinimumSize,
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+
+                Text = StageInfo.Title.ToUpper()
             };
+
+            AddChild(focusRect);
+            AddChild(label);
+
+            FocusEntered += () => CreateTween().TweenProperty(focusRect, "color", Colors.White, 0.3);
+            FocusExited += () => CreateTween().TweenProperty(focusRect, "color", Colors.Transparent, 0.3);
         }
     }
 }

--- a/XanaduProject.csproj
+++ b/XanaduProject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.1.0">
+<Project Sdk="Godot.NET.Sdk/4.1.1-rc.1">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/XanaduProject.csproj
+++ b/XanaduProject.csproj
@@ -4,7 +4,4 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <ItemGroup>
-    <Folder Include="Screens\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Sets up tabbing between stage panels in the stage selection menu, which will in turn allow for the corresponding song to be played in the menu. Said feature will be added in a follow up PR