### PR TITLE
Expose singletions via a source class 

### DIFF
--- a/Composer/Composer.cs
+++ b/Composer/Composer.cs
@@ -24,7 +24,7 @@ namespace XanaduProject.Composer
         {
             base._Ready();
 
-            audioSource = GetNode<AudioSource>("/root/GlobalAudio");
+            audioSource = SingletonSource.GetAudioSource();
             audioSource.SetTrack(StageInfo.TrackInfo);
 
             // Makes sure that the Composer's ready function is called after the core has loaded, avoiding the physics process being turned on automatically from there

--- a/Composer/Note.cs
+++ b/Composer/Note.cs
@@ -24,9 +24,7 @@ namespace XanaduProject.Composer
         {
             hitBox.Monitorable = false;
 
-            AudioSource audioSource = GetNode<AudioSource>("/root/GlobalAudio");
-
-            double deviation = Math.Abs(TimeSpan.FromSeconds(Position.X / Perception.BASE_VELOCITY - audioSource.TrackPosition).TotalMilliseconds);
+            double deviation = Math.Abs(TimeSpan.FromSeconds(Position.X / Perception.BASE_VELOCITY - SingletonSource.GetAudioSource().TrackPosition).TotalMilliseconds);
             var judgement = JudgementInfo.GetJudgement(deviation);
 
             judgementText.Text = JudgementInfo.GetJudgmentText(judgement).ToUpper();

--- a/Perceptions/Perception.cs
+++ b/Perceptions/Perception.cs
@@ -22,7 +22,7 @@ namespace XanaduProject.Perceptions
         [Export]
         protected Area2D NoteReceptor { get; set; } = null!;
         [Export]
-        protected Polygon2D Body { get; private set; }= null!;
+        protected Polygon2D Body { get; private set; } = null!;
         [Export]
         protected Area2D Nucleus { get; private set; } = null!;
 
@@ -40,7 +40,7 @@ namespace XanaduProject.Perceptions
 
             AddChild(new NoteProcessor(NoteReceptor));
 
-            AudioSource = GetNode<AudioSource>("/root/GlobalAudio");
+            AudioSource = SingletonSource.GetAudioSource();
             AudioSource.RequestPlay = true;
 
             GetNode<Area2D>("Shell").AreaEntered += _ =>

--- a/Screens/Player/PlayerLoader.cs
+++ b/Screens/Player/PlayerLoader.cs
@@ -30,7 +30,7 @@ namespace XanaduProject.Screens.Player
         {
             base._Ready();
 
-            AudioSource audioSource = GetNode<AudioSource>("/root/GlobalAudio");
+            AudioSource audioSource = SingletonSource.GetAudioSource();
 
             audioSource.SetTrack(stageInfo.TrackInfo);
 

--- a/Singletons/SingletonSource.cs
+++ b/Singletons/SingletonSource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) mk56_spn <dhsjplt@gmail.com>. Licensed under the GNU General Public Licence (2.0).
+// See the LICENCE file in the repository root for full licence text.
+
+using Godot;
+
+namespace XanaduProject.Singletons
+{
+    public static class SingletonSource
+    {
+        public static AudioSource GetAudioSource() =>
+            ((SceneTree)Engine.GetMainLoop()).Root.GetNode<AudioSource>("GlobalAudio");
+    }
+}

--- a/Tests/AudioTest.cs
+++ b/Tests/AudioTest.cs
@@ -43,7 +43,7 @@ namespace XanaduProject.Tests
 
         private void setup()
         {
-            audioSource = GetNode<AudioSource>("/root/GlobalAudio");
+            audioSource = SingletonSource.GetAudioSource();
             audioSource.SetTrack(ResourceLoader.Load<TrackInfo>("res://Resources/TestTrack.tres"));
 
             AddChild(container);


### PR DESCRIPTION
Makes any future refactors far easier, as path strings arent dumped in files across the project