### PR TITLE
Improve core rotation and fix threat detection hitbox not aligning with rotation

### DIFF
--- a/Perceptions/Core.cs
+++ b/Perceptions/Core.cs
@@ -1,7 +1,6 @@
 // Copyright (c) mk56_spn <dhsjplt@gmail.com>. Licensed under the GNU General Public Licence (2.0).
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using Godot;
 
 namespace XanaduProject.Perceptions
@@ -10,8 +9,6 @@ namespace XanaduProject.Perceptions
     {
         private const int jump_velocity = -1900;
 
-        private Tween? rotationTween;
-
         public override void _PhysicsProcess(double delta)
         {
             base._PhysicsProcess(delta);
@@ -19,36 +16,30 @@ namespace XanaduProject.Perceptions
             nucleus_collision();
 
             if (IsOnFloor())
-                ground_movement();
+                ground_movement(delta);
             else
                 air_movement(delta);
 
             MoveAndSlide();
         }
 
-        private void ground_movement()
+        private void ground_movement(double delta)
         {
-            grounded_rotation();
+            grounded_rotation(delta);
 
             if (Input.IsActionPressed("main"))
                 Velocity = new Vector2(Velocity.X, jump_velocity);
         }
 
-        private void grounded_rotation()
+        private void grounded_rotation(double delta)
         {
             float targetRotation = Mathf.Snapped(Body.RotationDegrees, 90);
 
-            if (rotationTween != null || !(Math.Abs(Body.RotationDegrees - targetRotation) > 0.01)) return;
-
-            rotationTween = CreateTween();
-            rotationTween.TweenProperty(Body, "rotation_degrees", targetRotation, 0.1);
+            Body.RotationDegrees = (float)Mathf.Lerp(Body.RotationDegrees, targetRotation, 20 * delta);
         }
 
         private void air_movement(double delta)
         {
-            // Ensure animation towards any floor alignment is ended immediately to avoid it continuing whilst in the air
-            rotationTween?.Kill();
-            rotationTween = null;
 
             Body.Rotate(Mathf.DegToRad(360 * (float)delta));
 

--- a/Perceptions/Core.tscn
+++ b/Perceptions/Core.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://Perceptions/Core.cs" id="1_opurh"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_rd2ky"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_x42nl"]
 size = Vector2(128, 128)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_x42nl"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_rd2ky"]
 size = Vector2(128, 128)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_hdcld"]
@@ -24,17 +24,18 @@ Nucleus = NodePath("Nucleus")
 [node name="Body" type="Polygon2D" parent="."]
 polygon = PackedVector2Array(-64, -64, -64, 64, 64, 64, 64, -64)
 
-[node name="Collision" type="CollisionShape2D" parent="."]
-shape = SubResource("RectangleShape2D_rd2ky")
-debug_color = Color(0, 0.6, 0.701961, 0.419608)
-
-[node name="Shell" type="Area2D" parent="."]
+[node name="Shell" type="Area2D" parent="Body"]
+unique_name_in_owner = true
 collision_layer = 0
 collision_mask = 8
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Shell"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Body/Shell"]
 shape = SubResource("RectangleShape2D_x42nl")
 debug_color = Color(0.343922, 0.616255, 0.215892, 0.42)
+
+[node name="Collision" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_rd2ky")
+debug_color = Color(0, 0.6, 0.701961, 0.419608)
 
 [node name="Nucleus" type="Area2D" parent="."]
 collision_layer = 2

--- a/Perceptions/Perception.cs
+++ b/Perceptions/Perception.cs
@@ -52,7 +52,7 @@ namespace XanaduProject.Perceptions
 
             AddChild(new NoteProcessor(NoteReceptor));
 
-            GetNode<Area2D>("Shell").AreaEntered += _ =>
+            GetNode<Area2D>("%Shell").AreaEntered += _ =>
                 SetPhysicsProcess(false);
 
             Nucleus.BodyEntered += _ =>


### PR DESCRIPTION
Self explanatory title lol. 

Using lerp for rotation removes the need for an awkward tween.